### PR TITLE
Allow editor flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/inconshreveable/mousetrap v1.1.0 // indirect
+require (
+	github.com/cosiner/argv v0.1.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+)
 
 require (
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cosiner/argv v0.1.0 h1:BVDiEL32lwHukgJKP87btEPenzrrHUjajs/8yzaqcXg=
+github.com/cosiner/argv v0.1.0/go.mod h1:EusR6TucWKX+zFgtdUsKT2Cvg45K5rtpCcWz4hK06d8=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
I wanted to open and edit documents in vscode but setting the editor to `code -w` didn't work so I investigated and changed the code to allow for editor flags. Vscode needs the "-w" flag block on the terminal until the edited file has been closed.
Otherwise the command immediately returns and confuses vi-mongo.

In hopes to make this as robust as possible I actually utilized a arg parsing module to hopefully account for weird edge cases in the binary path. I've only tested it with vscode tbh lol.

![image](https://github.com/user-attachments/assets/b232d07b-b3df-4bf5-b775-3c9c8de5c6ac)
