### PR TITLE
feat: add mongodb options to config so user can choose auth method

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,15 +16,21 @@ const (
 	LogPath    = "/tmp/vi-mongo.log"
 )
 
+type MongoOptions struct {
+	AuthorizedDatabases   *bool `yaml:"authorizedDatabases,omitempty"`
+	AuthorizedCollections *bool `yaml:"authorizedCollections,omitempty"`
+}
+
 type MongoConfig struct {
-	Uri      string `yaml:"url"`
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	Database string `yaml:"database"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-	Name     string `yaml:"name"`
-	Timeout  int    `yaml:"timeout"`
+	Uri      string       `yaml:"url"`
+	Host     string       `yaml:"host"`
+	Port     int          `yaml:"port"`
+	Database string       `yaml:"database"`
+	Username string       `yaml:"username"`
+	Password string       `yaml:"password"`
+	Name     string       `yaml:"name"`
+	Timeout  int          `yaml:"timeout"`
+	Options  MongoOptions `yaml:"options"`
 }
 
 type LogConfig struct {
@@ -242,6 +248,23 @@ func (m *MongoConfig) GetUri() string {
 func (m *MongoConfig) GetSafeUri() string {
 	uri := m.GetUri()
 	return util.HidePasswordInUri(uri)
+}
+
+// GetOptions returns the options from the config file
+// if they are not set, it returns the default values
+func (c *MongoConfig) GetOptions() MongoOptions {
+	boolPtr := true
+	defaults := MongoOptions{
+		AuthorizedDatabases:   &boolPtr,
+		AuthorizedCollections: &boolPtr,
+	}
+	if c.Options.AuthorizedDatabases == nil {
+		c.Options.AuthorizedDatabases = defaults.AuthorizedDatabases
+	}
+	if c.Options.AuthorizedCollections == nil {
+		c.Options.AuthorizedCollections = defaults.AuthorizedCollections
+	}
+	return c.Options
 }
 
 func ParseMongoDBURI(uri string) (host, port, db string, err error) {

--- a/internal/mongo/dao.go
+++ b/internal/mongo/dao.go
@@ -71,7 +71,7 @@ func (d *Dao) ListDbsWithCollections(ctx context.Context, nameRegex string) ([]D
 		filter = primitive.M{"name": primitive.Regex{Pattern: nameRegex, Options: "i"}}
 	}
 
-	listDbOptions := options.ListDatabases().SetAuthorizedDatabases(true)
+	listDbOptions := options.ListDatabases().SetAuthorizedDatabases(*d.Config.GetOptions().AuthorizedDatabases)
 	dbNames, err := d.client.ListDatabaseNames(ctx, filter, listDbOptions)
 	if err != nil {
 		log.Error().Err(err).Msg("Error listing databases")
@@ -79,7 +79,7 @@ func (d *Dao) ListDbsWithCollections(ctx context.Context, nameRegex string) ([]D
 	}
 
 	for _, dbName := range dbNames {
-		listCollOptions := options.ListCollections().SetAuthorizedCollections(true)
+		listCollOptions := options.ListCollections().SetAuthorizedCollections(*d.Config.GetOptions().AuthorizedCollections)
 
 		collNames, err := d.client.Database(dbName).ListCollectionNames(ctx, primitive.M{}, listCollOptions)
 		if err != nil {

--- a/internal/tui/page/welcome.go
+++ b/internal/tui/page/welcome.go
@@ -125,8 +125,8 @@ func (w *Welcome) renderForm() {
 
 	welcomeText := "All configuration can be set in " + configFile + " file. You can also set it here."
 	w.form.AddTextView("Welcome info", welcomeText, 0, 2, true, false)
-	w.form.AddTextView(" ", "-------------------------------------------", 0, 1, true, false)
-	w.form.AddTextView("Editor", "Set command (vim, nano etc) or env variable ($ENV) to open editor", 0, 2, true, false)
+	w.form.AddTextView(" ", "----------------------------------------------------------", 0, 1, true, false)
+	w.form.AddTextView("Editor", "Set command (vim, nano etc) or env ($ENV)", 0, 1, true, false)
 	editorCmd, err := cfg.GetEditorCmd()
 	if err != nil {
 		editorCmd = ""

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -74,7 +74,6 @@ func LoadConfigFile[T any](defaultConfig *T, configPath string) (*T, error) {
 		return nil, err
 	}
 
-	// Merge loaded config with default config
 	MergeConfigs(config, defaultConfig)
 
 	return config, nil


### PR DESCRIPTION
User is now able to set a flag that determines which databases/collections are returned based on user's given privliges
Fixes #34 