### PR TITLE
feat(ai/openai_driver): custom base url

### DIFF
--- a/internal/ai/openai_driver.go
+++ b/internal/ai/openai_driver.go
@@ -13,9 +13,14 @@ type OpenAIDriver struct {
 	systemMessage string
 }
 
-func NewOpenAIDriver(apiKey string) *OpenAIDriver {
+func NewOpenAIDriver(apiKey string, apiUrl string) *OpenAIDriver {
+	openAiClientCfg := openai.DefaultConfig(apiKey)
+	if apiUrl != "" {
+		openAiClientCfg.BaseURL = apiUrl
+	}
+	openAiClient := openai.NewClientWithConfig(openAiClientCfg)
 	return &OpenAIDriver{
-		client: openai.NewClient(apiKey),
+		client: openAiClient,
 	}
 }
 

--- a/internal/tui/component/ai_query.go
+++ b/internal/tui/component/ai_query.go
@@ -127,7 +127,11 @@ func (a *AIQuery) onSubmit() {
 			a.showError("OPENAI_API_KEY not found in environment variables")
 			return
 		}
-		driver = ai.NewOpenAIDriver(apiKey)
+		apiUrl := os.Getenv("OPENAI_API_BASE")
+		if apiUrl == "" {
+			apiUrl = "https://api.openai.com/v1"
+		}
+		driver = ai.NewOpenAIDriver(apiKey, apiUrl)
 	case slices.Contains(anthropicModels, model):
 		apiKey := os.Getenv("ANTHROPIC_API_KEY")
 		if apiKey == "" {

--- a/internal/tui/component/ai_query.go
+++ b/internal/tui/component/ai_query.go
@@ -128,9 +128,6 @@ func (a *AIQuery) onSubmit() {
 			return
 		}
 		apiUrl := os.Getenv("OPENAI_API_BASE")
-		if apiUrl == "" {
-			apiUrl = "https://api.openai.com/v1"
-		}
 		driver = ai.NewOpenAIDriver(apiKey, apiUrl)
 	case slices.Contains(anthropicModels, model):
 		apiKey := os.Getenv("ANTHROPIC_API_KEY")


### PR DESCRIPTION
Hi, thanks for the good tool, I use it daily.


This quick PR adds support to custom base url by setting the env:
```sh
export OPENAI_API_BASE="http://127.0.0.1:3000"
```

This is useful to use an OpenAI-compatible API. In my case, by using Copilot via an login proxy.