### PR TITLE
fix: single-item arrays not displaying in table view

### DIFF
--- a/internal/util/mongo.go
+++ b/internal/util/mongo.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/kopecmaciej/tview"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -68,7 +69,8 @@ func StringifyMongoValueByType(v any) string {
 		return t.Time().UTC().Format(time.RFC3339)
 	case primitive.A, primitive.D, primitive.M, map[string]any, []any:
 		b, _ := json.Marshal(t)
-		return string(b)
+		// Use tview's Escape function to prevent brackets from being interpreted as color tags
+		return tview.Escape(string(b))
 	case primitive.E:
 		return fmt.Sprintf("%v", t)
 	case primitive.Binary:

--- a/internal/util/mongo_test.go
+++ b/internal/util/mongo_test.go
@@ -45,7 +45,9 @@ func TestGetValueByType(t *testing.T) {
 		{"Bool", true, "true"},
 		{"ObjectID", objId, objId.Hex()},
 		{"DateTime", date, dateUtc},
-		{"Array", primitive.A{"a", "b"}, `["a","b"]`},
+		// Arrays use tview.Escape() so closing brackets become [] to prevent color tag interpretation
+		{"Array", primitive.A{"a", "b"}, `["a","b"[]`},
+		{"Single item array", primitive.A{"single"}, `["single"[]`},
 		{"Object", primitive.M{"key": "value"}, `{"key":"value"}`},
 		{"Null", nil, "null"},
 	}


### PR DESCRIPTION
Arrays with single items like ["item"] were not showing in the table because tview interpreted the brackets as color markup tags.

Fixed by using tview.Escape() to prevent bracket interpretation.