### PR TITLE
fix: make --config flag functional

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -74,7 +74,14 @@ func runApp(cmd *cobra.Command, args []string) {
 		fmt.Printf("Version %s%s\n", version, resetColor)
 		os.Exit(0)
 	}
-	cfg, err := config.LoadConfigWithVersion(version)
+
+	var cfg *config.Config
+	var err error
+	if cfgFile != "" {
+		cfg, err = config.LoadConfigWithCustomPath(version, cfgFile)
+	} else {
+		cfg, err = config.LoadConfigWithVersion(version)
+	}
 	if err != nil {
 		fatalf("loading config: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -18,7 +19,8 @@ const (
 )
 
 var (
-	EncryptionKey = ""
+	EncryptionKey   = ""
+	CustomConfigDir = "" // Custom config directory for --config flag
 )
 
 type MongoOptions struct {
@@ -95,6 +97,25 @@ func LoadConfigWithVersion(version string) (*Config, error) {
 		if err := cfg.UpdateConfig(); err != nil {
 			log.Error().Err(err).Msg("Failed to update config with new version")
 		}
+	}
+
+	return cfg, nil
+}
+
+func LoadConfigWithCustomPath(version string, customConfigPath string) (*Config, error) {
+	defaultConfig := &Config{}
+	defaultConfig.loadDefaults(version)
+
+	// Set custom config directory for styles and keybindings
+	CustomConfigDir = filepath.Dir(customConfigPath)
+
+	cfg, err := util.LoadConfigFile(defaultConfig, customConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.Version != version {
+		cfg.Version = version
 	}
 
 	return cfg, nil

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -634,7 +634,20 @@ func (k *Key) String() string {
 }
 
 func getKeybindingsPath() (string, error) {
-	configDir, err := util.GetConfigDir()
+	var configDir string
+	var err error
+
+	if CustomConfigDir != "" {
+		configDir = CustomConfigDir
+		// Check if keybindings file exists in custom directory
+		customKeybindingsPath := configDir + "/keybindings.json"
+		if _, err := os.Stat(customKeybindingsPath); err == nil {
+			return customKeybindingsPath, nil
+		}
+		// If not found in custom directory, fall back to default
+	}
+
+	configDir, err = util.GetConfigDir()
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/styles.go
+++ b/internal/config/styles.go
@@ -372,7 +372,20 @@ func isHexColor(s string) bool {
 }
 
 func getStylePath(styleName string) (string, error) {
-	configPath, err := util.GetConfigDir()
+	var configPath string
+	var err error
+
+	if CustomConfigDir != "" {
+		configPath = CustomConfigDir
+		// Check if style file exists in custom directory
+		customStylePath := fmt.Sprintf("%s/styles/%s", configPath, styleName)
+		if _, err := os.Stat(customStylePath); err == nil {
+			return customStylePath, nil
+		}
+		// If not found in custom directory, fall back to default
+	}
+
+	configPath, err = util.GetConfigDir()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Description
Fixes the `--config` flag that was defined but never used.

## Changes
- Add `LoadConfigWithCustomPath` function for custom config paths
- Implement fallback mechanism for styles and keybindings files  
- Maintain full backward compatibility

## Testing
```bash
# Test with custom config
vi-mongo --config /path/to/config.yaml

Fixes #95 