### PR TITLE
fix: tighten existing config file permissions on load

### DIFF
--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -103,6 +103,10 @@ func LoadConfigFile[T any](defaultConfig *T, configPath string) (*T, error) {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
+	if err := ensureFileMode(configPath); err != nil {
+		log.Warn().Err(err).Str("path", configPath).Msg("Failed to tighten config file permissions")
+	}
+
 	config := new(T)
 	err = unmarshalConfig(bytes, configPath, config)
 	if err != nil {
@@ -124,6 +128,17 @@ func LoadConfigFile[T any](defaultConfig *T, configPath string) (*T, error) {
 	}
 
 	return config, nil
+}
+
+func ensureFileMode(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm() == FileMode {
+		return nil
+	}
+	return os.Chmod(path, FileMode)
 }
 
 // marshalConfig marshals the config based on the file extension

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -356,4 +357,68 @@ func TestValidateConfigPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadConfigFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not enforced on Windows")
+	}
+
+	type yamlConfig struct {
+		Name string `yaml:"name"`
+	}
+
+	tests := []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "Tightens world-readable file", mode: 0644},
+		{name: "Tightens executable file", mode: 0744},
+		{name: "Tightens world-writable file", mode: 0666},
+		{name: "Keeps already restricted file", mode: 0600},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := t.TempDir() + "/config.yaml"
+			if err := os.WriteFile(configPath, []byte("name: custom\n"), 0600); err != nil {
+				t.Fatalf("Failed to write config file: %v", err)
+			}
+			if err := os.Chmod(configPath, tt.mode); err != nil {
+				t.Fatalf("Failed to chmod config file: %v", err)
+			}
+
+			cfg, err := LoadConfigFile(&yamlConfig{Name: "default"}, configPath)
+			if err != nil {
+				t.Fatalf("LoadConfigFile() error = %v", err)
+			}
+			if cfg.Name != "custom" {
+				t.Errorf("LoadConfigFile() Name = %q, want %q", cfg.Name, "custom")
+			}
+
+			info, err := os.Stat(configPath)
+			if err != nil {
+				t.Fatalf("Failed to stat config file: %v", err)
+			}
+			if perm := info.Mode().Perm(); perm != FileMode {
+				t.Errorf("Expected file mode %04o, got %04o", os.FileMode(FileMode), perm)
+			}
+		})
+	}
+
+	t.Run("Creates new file with restricted mode", func(t *testing.T) {
+		configPath := t.TempDir() + "/config.yaml"
+
+		if _, err := LoadConfigFile(&yamlConfig{Name: "default"}, configPath); err != nil {
+			t.Fatalf("LoadConfigFile() error = %v", err)
+		}
+
+		info, err := os.Stat(configPath)
+		if err != nil {
+			t.Fatalf("Failed to stat config file: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != FileMode {
+			t.Errorf("Expected file mode %04o, got %04o", os.FileMode(FileMode), perm)
+		}
+	})
 }


### PR DESCRIPTION
## Description

- Tighten permissions of existing config files to `0600` when they are loaded: `LoadConfigFile` now chmods any config whose mode differs from `FileMode`
- A chmod failure only logs a warning, so startup still works on filesystems that don't support permission changes (e.g. Windows-mounted drives under WSL)
- Add table-driven tests covering existing files with loose modes (`0644`/`0744`/`0666`), an already-restricted file, and newly created files

## Motivation

`config.yaml` can contain connection credentials. `FileMode` was changed from `0644` to `0600` in cbfa2b6 (March 3, 2026, first shipped in v0.1.35), but `os.WriteFile` only applies the mode when it creates the file — existing configs keep whatever permissions they already have. Since that change is only a few months old, anyone whose config predates v0.1.35 most likely still has a world-readable file today, even after upgrading (mine was `644`, exactly what older versions wrote; configs touched by external tooling are affected the same way). Loading now repairs the permissions instead of relying only on creation time.

## Testing

- `go build ./...` compiles cleanly
- `go test ./...` — all existing tests pass
- New `TestLoadConfigFilePermissions` (std lib only, matching the existing tests in `internal/util/config_test.go`) verifies: `0644`/`0744`/`0666` files are tightened to `0600` and their contents still load correctly, `0600` files are left untouched, and new files are created with `0600`; skipped on Windows where permission bits aren't enforced
- Manual: created a `config.yaml` with mode `644`, ran `vi-mongo --config <path> --connection-list` — connections listed correctly and the file was `0600` afterwards

Closes #120
