### PR TITLE
feat/config history limit

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	EncryptionKeyPath  *string       `yaml:"encryptionKeyPath,omitempty"`
 	JumpInto           string        `yaml:"-"`
 	ConfigPath         string        `yaml:"-"`
+	HistoryLimit       int           `yaml:"historyLimit,omitempty"`
 }
 
 // LoadConfig loads the config file
@@ -133,6 +134,7 @@ func (c *Config) loadDefaults(version string) {
 	}
 	c.ShowConnectionPage = true
 	c.ShowWelcomePage = true
+	c.HistoryLimit = 10
 }
 
 // GetConfigPath returns the path to the config file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,6 +105,7 @@ func TestUpdateConfig_CustomPath(t *testing.T) {
 	cfg.ShowWelcomePage = false
 	cfg.ShowConnectionPage = false
 	cfg.Log.Level = "warn"
+	cfg.HistoryLimit = 20
 
 	if err := cfg.UpdateConfig(); err != nil {
 		t.Fatalf("UpdateConfig failed: %v", err)
@@ -126,6 +127,10 @@ func TestUpdateConfig_CustomPath(t *testing.T) {
 
 	if savedConfig.ShowConnectionPage != false {
 		t.Error("Expected ShowConnectionPage to be false in saved config")
+	}
+
+	if savedConfig.HistoryLimit != 20 {
+		t.Errorf("Expected HistoryLimit to be 20 in saved config, got %d", savedConfig.HistoryLimit)
 	}
 
 	if savedConfig.Log.Level != "warn" {

--- a/internal/tui/modal/history.go
+++ b/internal/tui/modal/history.go
@@ -15,8 +15,6 @@ import (
 const (
 	HistoryModalId = "History"
 	QueryBarId     = "QueryBar"
-
-	maxHistory = 10
 )
 
 // History is a modal with history of queries
@@ -24,7 +22,8 @@ type History struct {
 	*core.BaseElement
 	*primitives.ListModal
 
-	style *config.HistoryStyle
+	style        *config.HistoryStyle
+	historyLimit int
 }
 
 func NewHistoryModal() *History {
@@ -44,6 +43,8 @@ func (h *History) init() error {
 	h.SetLayout()
 	h.setStyle()
 	h.setKeybindings()
+
+	h.historyLimit = h.App.GetConfig().HistoryLimit
 
 	return nil
 }
@@ -136,7 +137,7 @@ func (h *History) SaveToHistory(text string) error {
 	for _, line := range history {
 		if line != text {
 			updatedHistory = append(updatedHistory, line)
-			if len(updatedHistory) >= maxHistory {
+			if len(updatedHistory) >= h.historyLimit {
 				updatedHistory = updatedHistory[1:]
 			}
 		}


### PR DESCRIPTION
Adds `historyLimit` top-level property in `config.yaml` to set the limit
of history modal. Default remains 10.
